### PR TITLE
Speed up EI and PoI via numpy

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "python-envs.defaultEnvManager": "ms-python.python:conda",
+    "python-envs.defaultPackageManager": "ms-python.python:conda",
+    "python-envs.pythonProjects": []
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,0 @@
-{
-    "python-envs.defaultEnvManager": "ms-python.python:conda",
-    "python-envs.defaultPackageManager": "ms-python.python:conda",
-    "python-envs.pythonProjects": []
-}

--- a/src/Bgolearn/BgolearnFuns/BGOmax.py
+++ b/src/Bgolearn/BgolearnFuns/BGOmax.py
@@ -116,16 +116,9 @@ class Global_max(object):
         print('current optimal is :', cur_optimal_value)
 
         # Calculate Expected Improvement for each virtual sample
-        EI_list = []
-        for i in range(len(self.virtual_samples_mean)):
-            # Standardized improvement
-            Var_Z = (self.virtual_samples_mean[i] - cur_optimal_value) / self.virtual_samples_std[i]
-            # Expected Improvement formula
-            EI = (self.virtual_samples_mean[i] - cur_optimal_value) * norm.cdf(Var_Z) + self.virtual_samples_std[i] * norm.pdf(Var_Z)
-
-            EI_list.append(EI)
-       
-        EI_list = np.array(EI_list)
+        improv = self.virtual_samples_mean - cur_optimal_value
+        z = improv / self.virtual_samples_std
+        EI_list = improv * norm.cdf(z) +  self.virtual_samples_std * norm.pdf(z)
         
         return_x = []
         if self.opt_num == 1:
@@ -350,12 +343,7 @@ class Global_max(object):
                 print('The baseline is calculated based on the training dataset.')
                 cur_optimal_value = (1 + tao) * self.Measured_response.max() 
             print('The current optimal is :', cur_optimal_value)
-            PoI_list = []
-            for i in range(len(self.virtual_samples_mean)):
-                PoI = norm.cdf((self.virtual_samples_mean[i] - cur_optimal_value)/self.virtual_samples_std[i])
-                PoI_list.append(PoI)
-        
-            PoI_list = np.array(PoI_list)
+            PoI_list = norm.cdf((self.virtual_samples_mean - cur_optimal_value)/self.virtual_samples_std)
             
             return_x = []
             if self.opt_num == 1:

--- a/src/Bgolearn/BgolearnFuns/BGOmin.py
+++ b/src/Bgolearn/BgolearnFuns/BGOmin.py
@@ -115,15 +115,9 @@ class Global_min(object):
         print('current optimal is :', cur_optimal_value)
 
         # Calculate Expected Improvement for each virtual sample
-        EI_list = []
-        for i in range(len(self.virtual_samples_mean)):
-            # Standardized improvement (note: reversed for minimization)
-            Var_Z = (cur_optimal_value - self.virtual_samples_mean[i]) / self.virtual_samples_std[i]
-            # Expected Improvement formula for minimization
-            EI = (cur_optimal_value - self.virtual_samples_mean[i]) * norm.cdf(Var_Z) + self.virtual_samples_std[i] * norm.pdf(Var_Z)
-            EI_list.append(EI)
-       
-        EI_list = np.array(EI_list)
+        improv = cur_optimal_value - self.virtual_samples_mean
+        z = improv / self.virtual_samples_std
+        EI_list = improv * norm.cdf(z) + self.virtual_samples_std * norm.pdf(z)
 
         return_x = []
         if self.opt_num == 1:
@@ -342,12 +336,7 @@ class Global_min(object):
                 print('The baseline is calculated based on the training dataset.')
                 cur_optimal_value = (1 - tao) * self.Measured_response.min() 
             print('The current optimal is :', cur_optimal_value)
-            PoI_list = []
-            for i in range(len(self.virtual_samples_mean)):
-                PoI = norm.cdf((cur_optimal_value - self.virtual_samples_mean[i])/self.virtual_samples_std[i])
-                PoI_list.append(PoI)
-        
-            PoI_list = np.array(PoI_list)
+            PoI_list = norm.cdf((cur_optimal_value - self.virtual_samples_mean)/self.virtual_samples_std)
             
             return_x = []
             if self.opt_num == 1:


### PR DESCRIPTION
**Summary**

The original implementation of Expected Improvement (EI) and Probability of Improvement (PoI) used Python for-loops, resulting in slow performance (~45 minutes on my supercomputer for 14 million candidates in the virtual space). This update replaces the loops with efficient NumPy ndarray operations, achieving the same computational results without loss of accuracy.

**Performance Improvement**

- Before: ~45 minutes

- After: A few seconds

- Accuracy: Unchanged

This vectorized implementation significantly accelerates the acquisition function calculations while maintaining numerical correctness.